### PR TITLE
Create Github Workflow To Automate Publishing to NPM

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,35 @@
+name: Publish to NPM
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: windows-2019 # the build errored out on windows-2022 (currently windows-latest)
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
+
+      - name: Build the C++ solution
+        run: |
+          msbuild ./AutomationTtsEngine.sln -v:diag -property:Configuration=Release
+
+      - name: Inspect build outputs
+        run: |
+          ls 
+          cd Release/
+          ls
+
+      - name: Setup .npmrc file to publish to npm
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18 # Exact version not important
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish to NPM
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
# Create Github Workflow To Automate Publishing to NPM

## Description

- Adds in a Github Workflow that will run each time a new Github Release is manually made, and will try to publish the package to NPM 
    - A PR to manually update the version in package.json will be need to be merged each time prior to making the Github Release 

## Testing Notes

- I eventually got this to work in my fork (see [this run](https://github.com/sadikassistivlabs/aria-at-automation-driver/actions/runs/3333973599) and [the resulting package](https://www.npmjs.com/package/sadikassistivlabs-windows-sapi-tts-engine-for-automation))

## Next Steps for Maintainer(s)

Someone with access to Github Actions Secrets for the repository and who also has permissions to publish the package should

1. Follow [these instructions from NPM](https://docs.npmjs.com/creating-and-viewing-access-tokens) to create a new token for use in the publishing auth flow
    - The "Automation" choice should be picked for the type of Action token  
2. Follow [these instructions from Github](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) to create a new repository secret named `NPM_TOKEN`, and paste in the token copied from NPM into its Value field

This can be done before or after this PR is merged.