### PR TITLE
Add macos text service

### DIFF
--- a/src/macos/ATDriverGenericMacOS/ATDriverGenericMacOS.xcodeproj/project.pbxproj
+++ b/src/macos/ATDriverGenericMacOS/ATDriverGenericMacOS.xcodeproj/project.pbxproj
@@ -30,6 +30,16 @@
 		AD64B3B52B2B995C00AC0234 /* ATDriverGenericMacOSExtensionAudioUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD64B3B42B2B995C00AC0234 /* ATDriverGenericMacOSExtensionAudioUnit.swift */; };
 		AD64B3B82B2B995C00AC0234 /* Parameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD64B3B72B2B995C00AC0234 /* Parameters.swift */; };
 		AD64B3BB2B2B995C00AC0234 /* AudioUnitFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD64B3BA2B2B995C00AC0234 /* AudioUnitFactory.swift */; };
+		AD64B3DE2B33729C00AC0234 /* ATDriverGenericServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD64B3DD2B33729C00AC0234 /* ATDriverGenericServiceProtocol.swift */; };
+		AD64B3E02B33729C00AC0234 /* ATDriverGenericService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD64B3DF2B33729C00AC0234 /* ATDriverGenericService.swift */; };
+		AD64B3E22B33729C00AC0234 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD64B3E12B33729C00AC0234 /* main.swift */; };
+		AD64B3E72B33729C00AC0234 /* ATDriverGenericService.xpc in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = AD64B3DB2B33729C00AC0234 /* ATDriverGenericService.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		AD64B3ED2B462F2700AC0234 /* ATDriverClientIP.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD64B3EC2B462F2700AC0234 /* ATDriverClientIP.swift */; };
+		AD64B3EE2B4769EF00AC0234 /* ATDriverGenericServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD64B3DD2B33729C00AC0234 /* ATDriverGenericServiceProtocol.swift */; };
+		AD64B3F12B4772AC00AC0234 /* ATDriverClientUnix.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD64B3EF2B4772AC00AC0234 /* ATDriverClientUnix.swift */; };
+		AD64B3F32B47731000AC0234 /* ATDriverEventError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD64B3F22B47731000AC0234 /* ATDriverEventError.swift */; };
+		AD64B3F42B47731000AC0234 /* ATDriverEventError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD64B3F22B47731000AC0234 /* ATDriverEventError.swift */; };
+		AD87AD772B48ED8800C6E982 /* ATDriverGenericService.xpc in CopyFiles */ = {isa = PBXBuildFile; fileRef = AD64B3DB2B33729C00AC0234 /* ATDriverGenericService.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -54,6 +64,20 @@
 			remoteGlobalIDString = AD64B3A12B2B995C00AC0234;
 			remoteInfo = ATDriverGenericMacOSExtension;
 		};
+		AD64B3E52B33729C00AC0234 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = AD64B35D2B2B995B00AC0234 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = AD64B3DA2B33729C00AC0234;
+			remoteInfo = ATDriverGenericService;
+		};
+		AD87AD742B48ED7800C6E982 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = AD64B35D2B2B995B00AC0234 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = AD64B3DA2B33729C00AC0234;
+			remoteInfo = ATDriverGenericService;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -66,6 +90,27 @@
 				AD64B3A32B2B995C00AC0234 /* ATDriverGenericMacOSExtension.appex in Embed Foundation Extensions */,
 			);
 			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AD64B3EB2B33729C00AC0234 /* Embed XPC Services */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/XPCServices";
+			dstSubfolderSpec = 16;
+			files = (
+				AD64B3E72B33729C00AC0234 /* ATDriverGenericService.xpc in Embed XPC Services */,
+			);
+			name = "Embed XPC Services";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AD87AD762B48ED7C00C6E982 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/XPCServices";
+			dstSubfolderSpec = 16;
+			files = (
+				AD87AD772B48ED8800C6E982 /* ATDriverGenericService.xpc in CopyFiles */,
+			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -100,6 +145,16 @@
 		AD64B3B72B2B995C00AC0234 /* Parameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parameters.swift; sourceTree = "<group>"; };
 		AD64B3BA2B2B995C00AC0234 /* AudioUnitFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioUnitFactory.swift; sourceTree = "<group>"; };
 		AD64B3BC2B2B995C00AC0234 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AD64B3DB2B33729C00AC0234 /* ATDriverGenericService.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = ATDriverGenericService.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
+		AD64B3DD2B33729C00AC0234 /* ATDriverGenericServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATDriverGenericServiceProtocol.swift; sourceTree = "<group>"; };
+		AD64B3DF2B33729C00AC0234 /* ATDriverGenericService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATDriverGenericService.swift; sourceTree = "<group>"; };
+		AD64B3E12B33729C00AC0234 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		AD64B3E32B33729C00AC0234 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AD64B3E42B33729C00AC0234 /* ATDriverGenericService.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ATDriverGenericService.entitlements; sourceTree = "<group>"; };
+		AD64B3EC2B462F2700AC0234 /* ATDriverClientIP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATDriverClientIP.swift; sourceTree = "<group>"; };
+		AD64B3EF2B4772AC00AC0234 /* ATDriverClientUnix.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATDriverClientUnix.swift; sourceTree = "<group>"; };
+		AD64B3F22B47731000AC0234 /* ATDriverEventError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATDriverEventError.swift; sourceTree = "<group>"; };
+		AD87AD732B48EB3200C6E982 /* ATDriverGenericMacOSExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ATDriverGenericMacOSExtension.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -131,6 +186,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		AD64B3D82B33729C00AC0234 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -141,6 +203,7 @@
 				AD64B38F2B2B995C00AC0234 /* ATDriverGenericMacOSTests */,
 				AD64B3992B2B995C00AC0234 /* ATDriverGenericMacOSUITests */,
 				AD64B3A62B2B995C00AC0234 /* ATDriverGenericMacOSExtension */,
+				AD64B3DC2B33729C00AC0234 /* ATDriverGenericService */,
 				AD64B3662B2B995B00AC0234 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -152,6 +215,7 @@
 				AD64B38C2B2B995C00AC0234 /* ATDriverGenericMacOSTests.xctest */,
 				AD64B3962B2B995C00AC0234 /* ATDriverGenericMacOSUITests.xctest */,
 				AD64B3A22B2B995C00AC0234 /* ATDriverGenericMacOSExtension.appex */,
+				AD64B3DB2B33729C00AC0234 /* ATDriverGenericService.xpc */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -252,6 +316,7 @@
 		AD64B3A62B2B995C00AC0234 /* ATDriverGenericMacOSExtension */ = {
 			isa = PBXGroup;
 			children = (
+				AD87AD732B48EB3200C6E982 /* ATDriverGenericMacOSExtension.entitlements */,
 				AD64B3A72B2B995C00AC0234 /* README.md */,
 				AD64B3BC2B2B995C00AC0234 /* Info.plist */,
 				AD64B3A92B2B995C00AC0234 /* Common */,
@@ -313,6 +378,21 @@
 			path = AudioUnitFactory;
 			sourceTree = "<group>";
 		};
+		AD64B3DC2B33729C00AC0234 /* ATDriverGenericService */ = {
+			isa = PBXGroup;
+			children = (
+				AD64B3DD2B33729C00AC0234 /* ATDriverGenericServiceProtocol.swift */,
+				AD64B3DF2B33729C00AC0234 /* ATDriverGenericService.swift */,
+				AD64B3EC2B462F2700AC0234 /* ATDriverClientIP.swift */,
+				AD64B3EF2B4772AC00AC0234 /* ATDriverClientUnix.swift */,
+				AD64B3F22B47731000AC0234 /* ATDriverEventError.swift */,
+				AD64B3E12B33729C00AC0234 /* main.swift */,
+				AD64B3E32B33729C00AC0234 /* Info.plist */,
+				AD64B3E42B33729C00AC0234 /* ATDriverGenericService.entitlements */,
+			);
+			path = ATDriverGenericService;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -324,11 +404,13 @@
 				AD64B3622B2B995B00AC0234 /* Frameworks */,
 				AD64B3632B2B995B00AC0234 /* Resources */,
 				AD64B3C22B2B995C00AC0234 /* Embed Foundation Extensions */,
+				AD64B3EB2B33729C00AC0234 /* Embed XPC Services */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				AD64B3A52B2B995C00AC0234 /* PBXTargetDependency */,
+				AD64B3E62B33729C00AC0234 /* PBXTargetDependency */,
 			);
 			name = ATDriverGenericMacOS;
 			productName = ATDriverGenericMacOS;
@@ -378,15 +460,34 @@
 				AD64B39E2B2B995C00AC0234 /* Sources */,
 				AD64B39F2B2B995C00AC0234 /* Frameworks */,
 				AD64B3A02B2B995C00AC0234 /* Resources */,
+				AD87AD762B48ED7C00C6E982 /* CopyFiles */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				AD87AD752B48ED7800C6E982 /* PBXTargetDependency */,
 			);
 			name = ATDriverGenericMacOSExtension;
 			productName = ATDriverGenericMacOSExtension;
 			productReference = AD64B3A22B2B995C00AC0234 /* ATDriverGenericMacOSExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
+		};
+		AD64B3DA2B33729C00AC0234 /* ATDriverGenericService */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AD64B3E82B33729C00AC0234 /* Build configuration list for PBXNativeTarget "ATDriverGenericService" */;
+			buildPhases = (
+				AD64B3D72B33729C00AC0234 /* Sources */,
+				AD64B3D82B33729C00AC0234 /* Frameworks */,
+				AD64B3D92B33729C00AC0234 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ATDriverGenericService;
+			productName = ATDriverGenericService;
+			productReference = AD64B3DB2B33729C00AC0234 /* ATDriverGenericService.xpc */;
+			productType = "com.apple.product-type.xpc-service";
 		};
 /* End PBXNativeTarget section */
 
@@ -412,6 +513,9 @@
 					AD64B3A12B2B995C00AC0234 = {
 						CreatedOnToolsVersion = 14.3;
 					};
+					AD64B3DA2B33729C00AC0234 = {
+						CreatedOnToolsVersion = 14.3;
+					};
 				};
 			};
 			buildConfigurationList = AD64B3602B2B995B00AC0234 /* Build configuration list for PBXProject "ATDriverGenericMacOS" */;
@@ -431,6 +535,7 @@
 				AD64B38B2B2B995C00AC0234 /* ATDriverGenericMacOSTests */,
 				AD64B3952B2B995C00AC0234 /* ATDriverGenericMacOSUITests */,
 				AD64B3A12B2B995C00AC0234 /* ATDriverGenericMacOSExtension */,
+				AD64B3DA2B33729C00AC0234 /* ATDriverGenericService */,
 			);
 		};
 /* End PBXProject section */
@@ -465,6 +570,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				AD64B3A82B2B995C00AC0234 /* README.md in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AD64B3D92B33729C00AC0234 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -508,12 +620,27 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AD64B3F32B47731000AC0234 /* ATDriverEventError.swift in Sources */,
 				AD64B3B82B2B995C00AC0234 /* Parameters.swift in Sources */,
 				AD64B3AD2B2B995C00AC0234 /* ParameterSpecBase.swift in Sources */,
 				AD64B3B02B2B995C00AC0234 /* CrossPlatform.swift in Sources */,
 				AD64B3BB2B2B995C00AC0234 /* AudioUnitFactory.swift in Sources */,
+				AD64B3EE2B4769EF00AC0234 /* ATDriverGenericServiceProtocol.swift in Sources */,
 				AD64B3B22B2B995C00AC0234 /* String+Utils.swift in Sources */,
 				AD64B3B52B2B995C00AC0234 /* ATDriverGenericMacOSExtensionAudioUnit.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AD64B3D72B33729C00AC0234 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AD64B3F42B47731000AC0234 /* ATDriverEventError.swift in Sources */,
+				AD64B3E02B33729C00AC0234 /* ATDriverGenericService.swift in Sources */,
+				AD64B3DE2B33729C00AC0234 /* ATDriverGenericServiceProtocol.swift in Sources */,
+				AD64B3F12B4772AC00AC0234 /* ATDriverClientUnix.swift in Sources */,
+				AD64B3E22B33729C00AC0234 /* main.swift in Sources */,
+				AD64B3ED2B462F2700AC0234 /* ATDriverClientIP.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -534,6 +661,16 @@
 			isa = PBXTargetDependency;
 			target = AD64B3A12B2B995C00AC0234 /* ATDriverGenericMacOSExtension */;
 			targetProxy = AD64B3A42B2B995C00AC0234 /* PBXContainerItemProxy */;
+		};
+		AD64B3E62B33729C00AC0234 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = AD64B3DA2B33729C00AC0234 /* ATDriverGenericService */;
+			targetProxy = AD64B3E52B33729C00AC0234 /* PBXContainerItemProxy */;
+		};
+		AD87AD752B48ED7800C6E982 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = AD64B3DA2B33729C00AC0234 /* ATDriverGenericService */;
+			targetProxy = AD87AD742B48ED7800C6E982 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -656,6 +793,7 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
 				CLANG_CXX_LIBRARY = "libc++";
+				CODE_SIGN_ENTITLEMENTS = ATDriverGenericMacOSExtension/ATDriverGenericMacOSExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = UWBB3Z7TG8;
@@ -687,6 +825,7 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
 				CLANG_CXX_LIBRARY = "libc++";
+				CODE_SIGN_ENTITLEMENTS = ATDriverGenericMacOSExtension/ATDriverGenericMacOSExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = UWBB3Z7TG8;
@@ -861,6 +1000,52 @@
 			};
 			name = Release;
 		};
+		AD64B3E92B33729C00AC0234 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = ATDriverGenericService/ATDriverGenericService.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = UWBB3Z7TG8;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ATDriverGenericService/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = ATDriverGenericService;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bocoup.ATDriverGenericService;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		AD64B3EA2B33729C00AC0234 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = ATDriverGenericService/ATDriverGenericService.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = UWBB3Z7TG8;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ATDriverGenericService/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = ATDriverGenericService;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bocoup.ATDriverGenericService;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -905,6 +1090,15 @@
 			buildConfigurations = (
 				AD64B3CA2B2B995C00AC0234 /* Debug */,
 				AD64B3CB2B2B995C00AC0234 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AD64B3E82B33729C00AC0234 /* Build configuration list for PBXNativeTarget "ATDriverGenericService" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AD64B3E92B33729C00AC0234 /* Debug */,
+				AD64B3EA2B33729C00AC0234 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/src/macos/ATDriverGenericMacOS/ATDriverGenericMacOS.xcodeproj/project.pbxproj
+++ b/src/macos/ATDriverGenericMacOS/ATDriverGenericMacOS.xcodeproj/project.pbxproj
@@ -34,7 +34,6 @@
 		AD64B3E02B33729C00AC0234 /* ATDriverGenericService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD64B3DF2B33729C00AC0234 /* ATDriverGenericService.swift */; };
 		AD64B3E22B33729C00AC0234 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD64B3E12B33729C00AC0234 /* main.swift */; };
 		AD64B3E72B33729C00AC0234 /* ATDriverGenericService.xpc in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = AD64B3DB2B33729C00AC0234 /* ATDriverGenericService.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		AD64B3ED2B462F2700AC0234 /* ATDriverClientIP.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD64B3EC2B462F2700AC0234 /* ATDriverClientIP.swift */; };
 		AD64B3EE2B4769EF00AC0234 /* ATDriverGenericServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD64B3DD2B33729C00AC0234 /* ATDriverGenericServiceProtocol.swift */; };
 		AD64B3F12B4772AC00AC0234 /* ATDriverClientUnix.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD64B3EF2B4772AC00AC0234 /* ATDriverClientUnix.swift */; };
 		AD64B3F32B47731000AC0234 /* ATDriverEventError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD64B3F22B47731000AC0234 /* ATDriverEventError.swift */; };
@@ -151,7 +150,6 @@
 		AD64B3E12B33729C00AC0234 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		AD64B3E32B33729C00AC0234 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AD64B3E42B33729C00AC0234 /* ATDriverGenericService.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ATDriverGenericService.entitlements; sourceTree = "<group>"; };
-		AD64B3EC2B462F2700AC0234 /* ATDriverClientIP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATDriverClientIP.swift; sourceTree = "<group>"; };
 		AD64B3EF2B4772AC00AC0234 /* ATDriverClientUnix.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATDriverClientUnix.swift; sourceTree = "<group>"; };
 		AD64B3F22B47731000AC0234 /* ATDriverEventError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATDriverEventError.swift; sourceTree = "<group>"; };
 		AD87AD732B48EB3200C6E982 /* ATDriverGenericMacOSExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ATDriverGenericMacOSExtension.entitlements; sourceTree = "<group>"; };
@@ -383,7 +381,6 @@
 			children = (
 				AD64B3DD2B33729C00AC0234 /* ATDriverGenericServiceProtocol.swift */,
 				AD64B3DF2B33729C00AC0234 /* ATDriverGenericService.swift */,
-				AD64B3EC2B462F2700AC0234 /* ATDriverClientIP.swift */,
 				AD64B3EF2B4772AC00AC0234 /* ATDriverClientUnix.swift */,
 				AD64B3F22B47731000AC0234 /* ATDriverEventError.swift */,
 				AD64B3E12B33729C00AC0234 /* main.swift */,
@@ -640,7 +637,6 @@
 				AD64B3DE2B33729C00AC0234 /* ATDriverGenericServiceProtocol.swift in Sources */,
 				AD64B3F12B4772AC00AC0234 /* ATDriverClientUnix.swift in Sources */,
 				AD64B3E22B33729C00AC0234 /* main.swift in Sources */,
-				AD64B3ED2B462F2700AC0234 /* ATDriverClientIP.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -794,9 +790,9 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
 				CLANG_CXX_LIBRARY = "libc++";
 				CODE_SIGN_ENTITLEMENTS = ATDriverGenericMacOSExtension/ATDriverGenericMacOSExtension.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = UWBB3Z7TG8;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
@@ -813,6 +809,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bocoup.ATDriverGenericMacOS.ATDriverGenericMacOSExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "ATDriverGenericMacOSExtension/Common/ATDriverGenericMacOSExtension-Bridging-Header.h";
@@ -826,9 +823,9 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
 				CLANG_CXX_LIBRARY = "libc++";
 				CODE_SIGN_ENTITLEMENTS = ATDriverGenericMacOSExtension/ATDriverGenericMacOSExtension.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = UWBB3Z7TG8;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
@@ -845,6 +842,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bocoup.ATDriverGenericMacOS.ATDriverGenericMacOSExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "ATDriverGenericMacOSExtension/Common/ATDriverGenericMacOSExtension-Bridging-Header.h";
@@ -859,11 +857,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = ATDriverGenericMacOS/ATDriverGenericMacOS.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"ATDriverGenericMacOS/Preview Content\"";
-				DEVELOPMENT_TEAM = UWBB3Z7TG8;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -885,6 +884,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.bocoup.ATDriverGenericMacOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 			};
@@ -897,11 +897,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = ATDriverGenericMacOS/ATDriverGenericMacOS.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"ATDriverGenericMacOS/Preview Content\"";
-				DEVELOPMENT_TEAM = UWBB3Z7TG8;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -923,6 +924,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.bocoup.ATDriverGenericMacOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 			};
@@ -1004,10 +1006,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ATDriverGenericService/ATDriverGenericService.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = UWBB3Z7TG8;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ATDriverGenericService/Info.plist;
@@ -1017,6 +1019,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bocoup.ATDriverGenericService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -1027,10 +1030,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ATDriverGenericService/ATDriverGenericService.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = UWBB3Z7TG8;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ATDriverGenericService/Info.plist;
@@ -1040,6 +1043,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bocoup.ATDriverGenericService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/src/macos/ATDriverGenericMacOS/ATDriverGenericMacOS.xcodeproj/xcshareddata/xcschemes/ATDriverGenericMacOSExtension.xcscheme
+++ b/src/macos/ATDriverGenericMacOS/ATDriverGenericMacOS.xcodeproj/xcshareddata/xcschemes/ATDriverGenericMacOSExtension.xcscheme
@@ -43,6 +43,30 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AD64B3952B2B995C00AC0234"
+               BuildableName = "ATDriverGenericMacOSUITests.xctest"
+               BlueprintName = "ATDriverGenericMacOSUITests"
+               ReferencedContainer = "container:ATDriverGenericMacOS.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AD64B38B2B2B995C00AC0234"
+               BuildableName = "ATDriverGenericMacOSTests.xctest"
+               BlueprintName = "ATDriverGenericMacOSTests"
+               ReferencedContainer = "container:ATDriverGenericMacOS.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/src/macos/ATDriverGenericMacOS/ATDriverGenericMacOSExtension/ATDriverGenericMacOSExtension.entitlements
+++ b/src/macos/ATDriverGenericMacOS/ATDriverGenericMacOSExtension/ATDriverGenericMacOSExtension.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/src/macos/ATDriverGenericMacOS/ATDriverGenericService/ATDriverClientUnix.swift
+++ b/src/macos/ATDriverGenericMacOS/ATDriverGenericService/ATDriverClientUnix.swift
@@ -1,0 +1,87 @@
+//
+//  ATDriverClientUnix.swift
+//  ATDriverGenericMacOS
+//
+//  Created by Z Goddard on 1/4/24.
+//
+
+import Foundation
+
+class ATDriverClientUnix {
+
+  class SocketResource {
+    var descriptor: Int32
+    init() throws {
+      descriptor = socket(
+        AF_UNIX,
+        SOCK_STREAM,
+        0)
+      guard descriptor > -1 else {
+        throw ATDriverEventError.badSocketSettings(posixErrorString())
+      }
+    }
+    deinit {
+      close(descriptor)
+    }
+  }
+
+  static let pipe = "/usr/local/var/at_driver_generic/driver.socket"
+
+  func sendInitEvent() throws {
+    try self._sendEvent(name: "lifecycle", data: "hello")
+  }
+
+  func sendGoodbyeEvent() throws {
+    try self._sendEvent(name: "lifecycle", data: "goodbye")
+  }
+
+  func sendSpeechEvent(speech: String) throws {
+    try self._sendEvent(name: "speech", data: speech)
+  }
+
+  func sendCancelEvent() throws {
+    try self._sendEvent(name: "lifecycle", data: "cancel")
+  }
+
+  func _connect() throws -> SocketResource {
+    let socket = try SocketResource()
+
+    var unixAddr = sockaddr_un()
+    let pathSize = size_t(MemoryLayout.size(ofValue: unixAddr.sun_path))
+    unixAddr.sun_family = sa_family_t(AF_UNIX)
+    ATDriverClientUnix.pipe.withCString { pipeAddress in
+      strncpy(&unixAddr.sun_path, pipeAddress, pathSize)
+      return
+    }
+
+    let unixAddrSize = socklen_t(MemoryLayout.size(ofValue: unixAddr))
+    // Get UnsafePointer to addr
+    try withUnsafePointer(to: &unixAddr) { unsafeUnixAddr in
+      // Cast UnsafePointer<sockaddr_un> to UnsafePointer<sockaddr>
+      try unsafeUnixAddr.withMemoryRebound(to: sockaddr.self, capacity: 1) { addr in
+        guard connect(socket.descriptor, addr, unixAddrSize) > -1 else {
+          throw ATDriverEventError.didNotConnect(posixErrorString())
+        }
+      }
+    }
+
+    return socket
+  }
+
+  func _makeMessage(name: String, data: String) -> String {
+    return "\(name):\(data)"
+  }
+
+  func _sendEvent(name: String, data: String) throws {
+    let socket = try _connect()
+
+    let message = _makeMessage(name: name, data: data)
+
+    try message.utf8CString.withUnsafeBufferPointer { unsafeMessageBuffer in
+      let unsafeMessage = unsafeMessageBuffer.baseAddress!
+      guard write(socket.descriptor, unsafeMessage, strlen(unsafeMessage)) > -1 else {
+        throw ATDriverEventError.sendFailure(posixErrorString())
+      }
+    }
+  }
+}

--- a/src/macos/ATDriverGenericMacOS/ATDriverGenericService/ATDriverEventError.swift
+++ b/src/macos/ATDriverGenericMacOS/ATDriverGenericService/ATDriverEventError.swift
@@ -1,0 +1,21 @@
+//
+//  ATDriverEventError.swift
+//  ATDriverGenericMacOS
+//
+//  Created by Z Goddard on 1/4/24.
+//
+
+import Foundation
+
+enum ATDriverEventError: Error {
+  /// Failed to allocate socket resource with given settings.
+  case badSocketSettings(String)
+  /// Failed to connect to remote.
+  case didNotConnect(String)
+  /// Failed to write data to socket.
+  case sendFailure(String)
+}
+
+func posixErrorString() -> String {
+  return String(cString: strerror(errno))
+}

--- a/src/macos/ATDriverGenericMacOS/ATDriverGenericService/ATDriverGenericService.entitlements
+++ b/src/macos/ATDriverGenericMacOS/ATDriverGenericService/ATDriverGenericService.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/src/macos/ATDriverGenericMacOS/ATDriverGenericService/ATDriverGenericService.swift
+++ b/src/macos/ATDriverGenericMacOS/ATDriverGenericService/ATDriverGenericService.swift
@@ -1,0 +1,49 @@
+//
+//  ATDriverGenericService.swift
+//  ATDriverGenericService
+//
+//  Created by Z Goddard on 12/20/23.
+//
+
+import Foundation
+import os
+
+class ATDriverGenericService: NSObject, ATDriverGenericServiceProtocol {
+  let logger = Logger(subsystem: "com.bocoup.ATDriverGeneric", category: "service")
+  let client = ATDriverClientUnix()
+
+  deinit {
+    do {
+      try client.sendGoodbyeEvent()
+    } catch {
+      logger.error("error sending goodbye event: \(String(reflecting: error), privacy: .public)")
+    }
+  }
+
+  @objc func postInitEvent() {
+    logger.log("received init event")
+    do {
+      try client.sendInitEvent()
+    } catch {
+      logger.error("error sending init event: \(String(reflecting: error), privacy: .public)")
+    }
+  }
+
+  @objc func postSpeechEvent(speech: String) {
+    logger.log("received speech event")
+    do {
+      try client.sendSpeechEvent(speech: speech)
+    } catch {
+      logger.error("error sending speech event: \(String(reflecting: error), privacy: .public)")
+    }
+  }
+
+  @objc func postCancelEvent() {
+    logger.log("received cancel event")
+    do {
+      try client.sendCancelEvent()
+    } catch {
+      logger.error("error sending cancel event: \(String(reflecting: error), privacy: .public)")
+    }
+  }
+}

--- a/src/macos/ATDriverGenericMacOS/ATDriverGenericService/ATDriverGenericServiceProtocol.swift
+++ b/src/macos/ATDriverGenericMacOS/ATDriverGenericService/ATDriverGenericServiceProtocol.swift
@@ -1,0 +1,14 @@
+//
+//  ATDriverGenericServiceProtocol.swift
+//  ATDriverGenericService
+//
+//  Created by Z Goddard on 12/20/23.
+//
+
+import Foundation
+
+@objc protocol ATDriverGenericServiceProtocol {
+  func postInitEvent()
+  func postSpeechEvent(speech: String)
+  func postCancelEvent()
+}

--- a/src/macos/ATDriverGenericMacOS/ATDriverGenericService/Info.plist
+++ b/src/macos/ATDriverGenericMacOS/ATDriverGenericService/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>XPCService</key>
+	<dict>
+		<key>ServiceType</key>
+		<string>Application</string>
+	</dict>
+</dict>
+</plist>

--- a/src/macos/ATDriverGenericMacOS/ATDriverGenericService/main.swift
+++ b/src/macos/ATDriverGenericMacOS/ATDriverGenericService/main.swift
@@ -1,0 +1,41 @@
+//
+//  main.swift
+//  ATDriverGenericService
+//
+//  Created by Z Goddard on 12/20/23.
+//
+
+import Foundation
+
+class ServiceDelegate: NSObject, NSXPCListenerDelegate {
+
+  /// This method is where the NSXPCListener configures, accepts, and resumes a new incoming NSXPCConnection.
+  func listener(_ listener: NSXPCListener, shouldAcceptNewConnection newConnection: NSXPCConnection)
+    -> Bool
+  {
+
+    // Configure the connection.
+    // First, set the interface that the exported object implements.
+    newConnection.exportedInterface = NSXPCInterface(with: ATDriverGenericServiceProtocol.self)
+
+    // Next, set the object that the connection exports. All messages sent on the connection to this service will be sent to the exported object to handle. The connection retains the exported object.
+    let exportedObject = ATDriverGenericService()
+    newConnection.exportedObject = exportedObject
+
+    // Resuming the connection allows the system to deliver more incoming messages.
+    newConnection.resume()
+
+    // Returning true from this method tells the system that you have accepted this connection. If you want to reject the connection for some reason, call invalidate() on the connection and return false.
+    return true
+  }
+}
+
+// Create the delegate for the service.
+let delegate = ServiceDelegate()
+
+// Set up the one NSXPCListener for this service. It will handle all incoming connections.
+let listener = NSXPCListener.service()
+listener.delegate = delegate
+
+// Resuming the serviceListener starts this service. This method does not return.
+listener.resume()


### PR DESCRIPTION
Depends on #30 and #31.

## Summary

Add an XPC Service, called `ATDriverGenericService`, to the xcode project. This service handles communication between the AudioUnit and the `lib/cli.js` nodejs executable. 

## Changes

- Add ATDriverGenericService to xcode project
- Add service build dependency to Extension
- Add unix socket path to cli.js
- Create directory for socket and unlink old leftover sockets in cli.js

## Description

XPC Services are useful for separating some work into another process. In this case this change uses a service to separate socket communication with a nodejs process. This way the blocking calls to bsd socket apis are done in a process other then the one the audio unit runs its synthesis in.

The extension creates an XPCConnection designating the target service and protocol. With that, the extension calls methods on a proxy with the same interface as the protocol. The methods queue messages to be sent. When the service is created and starts, it receives and processes those message. As implemented this service than produces messages in the format `cli.js` expects and opens a unix family socket to send the message.

### Adding an Service in Xcode

When adding the service Xcode added the service as a build dependency to the container application. For the extension to be able to use the service it has been added as a build dependency to the extension as well.
