### PR TITLE
Fix 'rejects invalid pressKey' test

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -180,7 +180,7 @@ suite('at-driver', () => {
       assert.deepEqual(message, {
         id: 902,
         error: 'unknown error',
-        message: 'Invalid key code specified.',
+        message: 'unknown key (\\u64)',
       });
     });
 


### PR DESCRIPTION
The test `rejects invalid "pressKey"` currently fails. The underlying behaviour does not return the expected message but a different one. Fix the message to what the current behaviour returns.