### PR TITLE
Correct test for voice events

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -33,8 +33,9 @@ suite('at-driver', () => {
   };
   const sendVoicePacket = async (type, data) => {
     const socketPath = await prepareSocketPath();
-    const stream = await new Promise(resolve => {
+    const stream = await new Promise((resolve, reject) => {
       const stream = net.connect(socketPath);
+      stream.on('error', reject);
       stream.on('connect', () => resolve(stream));
     });
     await new Promise(resolve => stream.end(`${type}:${data}`, 'utf8', resolve));


### PR DESCRIPTION
[The test titled 'sends voice events'](https://github.com/w3c/aria-at-automation-driver/blob/2aa23720c5fa87206ed70522f69c31aa65965d3b/test/test.js#L204-L215) consistently fails on my system. The issue is partially obscured by an unhandled error event, and this patch addresses that deficiency. However, the real problem seems to come from mishandling the UNIX domain socket, and I have yet to implement a fix.

Here's the sequence of events, as I understand them:

1. [The test's setup logic executes the application](https://github.com/w3c/aria-at-automation-driver/blob/2aa23720c5fa87206ed70522f69c31aa65965d3b/test/test.js#L106)
2. [The applications creates a UNIX domain socket](https://github.com/w3c/aria-at-automation-driver/blob/2aa23720c5fa87206ed70522f69c31aa65965d3b/lib/create-voice-server.js#L34-L44)
3. [`sendVoicePacket` calls `prepareSocketPatch`](https://github.com/w3c/aria-at-automation-driver/blob/2aa23720c5fa87206ed70522f69c31aa65965d3b/test/test.js#L35)
4. [`prepareSocketPath` destroys the socket](https://github.com/w3c/aria-at-automation-driver/blob/2aa23720c5fa87206ed70522f69c31aa65965d3b/lib/cli.js#L75)
5. [`sendVoicePacket` attempts to connect to a non-existent socket](https://github.com/w3c/aria-at-automation-driver/blob/2aa23720c5fa87206ed70522f69c31aa65965d3b/test/test.js#L37)

@gnarf @mzgoddard we added this in gh-31, so I'm wondering if you see any error in my summary or know whether this test ever worked in macOS.