### PR TITLE
Force ATDriverGenericMacOSExtensionAudioUnit channel capabilities to no input, mono output

### DIFF
--- a/src/macos/ATDriverGenericMacOS/ATDriverGenericMacOSExtension/Common/Audio Unit/ATDriverGenericMacOSExtensionAudioUnit.swift
+++ b/src/macos/ATDriverGenericMacOS/ATDriverGenericMacOSExtension/Common/Audio Unit/ATDriverGenericMacOSExtensionAudioUnit.swift
@@ -52,6 +52,11 @@ public class ATDriverGenericMacOSExtensionAudioUnit: AVSpeechSynthesisProviderAu
         logger.log("initialized")
     }
     
+    public override var channelCapabilities: [NSNumber]? {
+        // Specifies that the Audio Unit supports no input channels and exactly one output channel.
+        return [0, 1]
+    }
+
     deinit {
         messenger.invalidate()
     }


### PR DESCRIPTION
This was required to complete installation on my system. 

It seems that if the system has a broader set of output capabilities, this can invalidate the`AudioUnit` due to a mismatch between its announced capabilities and the host's expectations. 

Prior to this change, the `auval -v ausp atdg BOCU` portion of the`at-driver install` script produced this error on both my system and @boazsender 's.

```
Error: Command failed: auval -v ausp atdg BOCU

    at ChildProcess.exithandler (node:child_process:422:12)
    at ChildProcess.emit (node:events:517:28)
    at maybeClose (node:internal/child_process:1098:16)
    at ChildProcess._handle.onexit (node:internal/child_process:303:5) {
  code: 255,
  killed: false,
  signal: null,
  cmd: 'auval -v ausp atdg BOCU',
  stdout: '\n' +
    '    AU Validation Tool\n' +
    '    Version: 1.10.0 \n' +
    '    Copyright 2003-2019, Apple Inc. All Rights Reserved.\n' +
    '    Specify -h (-help) for command options\n' +
    '\n' +
    '--------------------------------------------------\n' +
    "VALIDATING AUDIO UNIT: 'ausp' - 'atdg' - 'BOCU'\n" +
    '--------------------------------------------------\n' +
    'Manufacturer String: Bocoup LLC\n' +
    'AudioUnit Name: ATDriverGenericMacOSExtension\n' +
    'Component Version: 1.6.0 (0x10600)\n' +
    '\n' +
    '* * PASS\n' +
    '--------------------------------------------------\n' +
    'TESTING OPEN TIMES:\n' +
    'COLD:\n' +
    '\n' +
    'Loaded AudioUnit out-of-process: true \n' +
    'Time to open AudioUnit:         107.285 ms\n' +
    'WARM:\n' +
    '\n' +
    'Loaded AudioUnit out-of-process: true \n' +
    'Time to open AudioUnit:         105.172  ms\n' +
    'This AudioUnit is a version 3 implementation.\n' +
    'FIRST TIME:\n' +
    'Time for initialization:        31.114 ms\n' +
    '\n' +
    '* * PASS\n' +
    '--------------------------------------------------\n' +
    'VERIFYING DEFAULT SCOPE FORMATS:\n' +
    'Input Scope Bus Configuration:\n' +
    ' Default Bus Count:0\n' +
    '\n' +
    'Output Scope Bus Configuration:\n' +
    ' Default Bus Count:1\n' +
    '    Default Format: AudioStreamBasicDescription:  1 ch,  22050 Hz, Float32\n' +
    '\n' +
    '* * PASS\n' +
    '--------------------------------------------------\n' +
    'VERIFYING REQUIRED PROPERTIES:\n' +
    '\n' +
    '* * PASS\n' +
    '--------------------------------------------------\n' +
    'VERIFYING RECOMMENDED PROPERTIES:\n' +
    '\n' +
    '* * PASS\n' +
    '--------------------------------------------------\n' +
    'VERIFYING OPTIONAL PROPERTIES:\n' +
    '  VERIFYING PROPERTY: Latency\n' +
    '    PASS\n' +
    '  VERIFYING PROPERTY: Tail Time\n' +
    '    PASS\n' +
    '  VERIFYING PROPERTY: Bypass Effect\n' +
    '    PASS\n' +
    '\n' +
    '* * PASS\n' +
    '--------------------------------------------------\n' +
    'VERIFYING SPECIAL PROPERTIES:\n' +
    '\n' +
    'VERIFYING CUSTOM UI\n' +
    'Cocoa Views Available: 0\n' +
    'WARNING: CurrentPreset property is deprectated. AU should implement PresentPreset\n' +
    '\n' +
    'VERIFYING CLASS INFO\n' +
    '    PASS\n' +
    '\n' +
    'TESTING HOST CALLBACKS\n' +
    '    PASS\n' +
    '\n' +
    '* * PASS\n' +
    '--------------------------------------------------\n' +
    'PUBLISHED PARAMETER INFO:\n' +
    '\n' +
    '# # # 1 Global Scope Parameters:\n' +
    '\n' +
    '# # Parameters for clump: 212950\n' +
    '# Full Clump Name: Global\n' +
    '# Short (4 Chars limit) Clump Name: Global\n' +
    'Parameter ID:1703748195\n' +
    'Name: Output Gain\n' +
    'Parameter Type: Linear Gain\n' +
    'Values: Minimum = 0.000000, Default = 0.250000, Maximum = 1.000000\n' +
    'Flags: Readable, Writable \n' +
    '  -parameter PASS\n' +
    '\n' +
    'Testing that parameters retain value across reset and initialization\n' +
    '  PASS\n' +
    '\n' +
    '* * PASS\n' +
    '--------------------------------------------------\n' +
    'FORMAT TESTS:\n' +
    '\n' +
    'Reported Channel Capabilities\n' +
    '\n' +
    'No Input, Output Chans:\n' +
    '0-1   0-2   0-4   0-5   0-6   0-7   0-8\n' +
    'X                                         \n' +
    'WARNING: Can Initialize Unit to un-supported num channels:InputChan:0, OutputChan:2\n' +
    'WARNING: Can Initialize Unit to un-supported num channels:InputChan:0, OutputChan:4\n' +
    'WARNING: Can Initialize Unit to un-supported num channels:InputChan:0, OutputChan:5\n' +
    'WARNING: Can Initialize Unit to un-supported num channels:InputChan:0, OutputChan:6\n' +
    'WARNING: Can Initialize Unit to un-supported num channels:InputChan:0, OutputChan:7\n' +
    'WARNING: Can Initialize Unit to un-supported num channels:InputChan:0, OutputChan:8\n' +
    'ERROR: Unit Needs to describe its channel handling capabilities (at least for default config: in:0, out:1)\n' +
    '\n' +
    '* * FAIL\n' +
    '--------------------------------------------------\n' +
    'RENDER TESTS:\n' +
    'ERROR:   Format errors. Cannot perform render tests\n' +
    '\n' +
    '\n' +
    '* * FAIL\n' +
    '--------------------------------------------------\n' +
    'AU VALIDATION FAILED: CORRECT THE ERRORS ABOVE.\n' +
    '--------------------------------------------------\n',
  stderr: ''
  ```
 