### PR TITLE
Support macOS 14

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -8,12 +8,21 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-2022]
+        os: [windows-2022, macos-14]
         node-version: ['18.x']
         test-command:
           - npm run test-style
           - npm run test-types
           - npm run test-unit
+        exclude:
+          # The `test-style` script is platform-independent, so there is no
+          # value in executing it in multiple operating systems.
+          - os: macos-14
+            test-command: npm run test-style
+          # The `test-types` script is platform-independent, so there is no
+          # value in executing it in multiple operating systems.
+          - os: macos-14
+            test-command: npm run test-types
 
     steps:
       - uses: actions/checkout@v4

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -6,8 +6,8 @@ const createCommandServer = require('../create-command-server');
 const createVoiceServer = require('../create-voice-server');
 
 const WINDOWS_NAMED_PIPE = '\\\\?\\pipe\\my_pipe';
-const MACOS_SYSTEM_DIR = '/usr/local/var/at_driver_generic';
-const MACOS_SOCKET_UNIX_PATH = '/usr/local/var/at_driver_generic/driver.socket';
+const MACOS_SYSTEM_DIR = '/tmp/at_driver_generic';
+const MACOS_SOCKET_UNIX_PATH = '/tmp/at_driver_generic/driver.socket';
 const DEFAULT_PORT = 4382;
 
 /**

--- a/src/macos/ATDriverGenericMacOS/ATDriverGenericService/ATDriverClientUnix.swift
+++ b/src/macos/ATDriverGenericMacOS/ATDriverGenericService/ATDriverClientUnix.swift
@@ -25,7 +25,7 @@ class ATDriverClientUnix {
     }
   }
 
-  static let pipe = "/usr/local/var/at_driver_generic/driver.socket"
+  static let pipe = "/tmp/at_driver_generic/driver.socket"
 
   func sendInitEvent() throws {
     try self._sendEvent(name: "lifecycle", data: "hello")

--- a/test/test.js
+++ b/test/test.js
@@ -8,7 +8,7 @@ const WebSocket = require('ws');
 
 const SOCKET_PATH = {
   win32: '\\\\?\\pipe\\my_pipe',
-  darwin: '/usr/local/var/at_driver_generic/driver.socket',
+  darwin: '/tmp/at_driver_generic/driver.socket',
 }[process.platform];
 
 const executable = path.join(__dirname, '..', 'bin', 'at-driver');


### PR DESCRIPTION
macOS version 14 removed the `/usr/local/var/` directory. `/run/` and `/var/run/` are defined by the Filesystem Hierarchy Standard for the purpose of UNIX-domain sockets [^1]. However, macOS 14 does not include `/run/`, and `/var/run/` is not world-writable on that platform. In order to support macOS 14, use the `/tmp/` directory, instead. Extend the configuration of the project's continuous integration environment to include macOS 14.

[^1]: https://refspecs.linuxfoundation.org/FHS_3.0/index.html